### PR TITLE
Remove the meta field when we find it. 

### DIFF
--- a/com/dongxiguo/continuation/Continuation.hx
+++ b/com/dongxiguo/continuation/Continuation.hx
@@ -159,9 +159,15 @@ class Continuation
         case FFun(f):
         {
           var originReturnType = f.ret;
-          for (m in field.meta)
+          var originMeta = field.meta;
+          field.meta = [];
+          for (m in originMeta)
           {
-            if (m.name == metaName)
+            if (m.name != metaName)
+            {
+              field.meta.push(m);
+            }
+            else
             {
               f.args = f.args.concat(
                 [


### PR DESCRIPTION
Allows for two classes to implement Async and then inherit from each other.

interface IFoo extends continuation.Async{}
class Foo implements IFoo{}

interface IBar extends continuation.Async{}
class Bar extends Foo implements IBar {}
- [ ] @dogles 
