### PR TITLE
Haxe 3.3 Iterator fix

### DIFF
--- a/com/dongxiguo/continuation/Continuation.hx
+++ b/com/dongxiguo/continuation/Continuation.hx
@@ -846,16 +846,8 @@ class ContinuationDetail
             return transform(
               macro
               {
-                var __iterator = null;
-                {
-                  inline function setIterator<T>(
-                    iterable:Iterable<T> = null,
-                    iterator:Iterator<T> = null):Void
-                  {
-                    __iterator = iterable != null ? iterable.iterator() : iterator;
-                  }
-                  setIterator($e2);
-                }
+
+                var __iterator = com.dongxiguo.continuation.utils.IteratorHelper.get($e2);
                 while (__iterator.hasNext())
                 {
                   var $elementName = __iterator.next();

--- a/com/dongxiguo/continuation/utils/IteratorHelper.hx
+++ b/com/dongxiguo/continuation/utils/IteratorHelper.hx
@@ -1,0 +1,14 @@
+package com.dongxiguo.continuation.utils;
+
+@:forward
+abstract IteratorHelper<T>(Iterator<T>) from Iterator<T> {
+  @:from inline public static function fromIterable<T>(iterable:Iterable<T>):IteratorHelper<T> {
+    return iterable.iterator();
+  }
+
+  inline public static function get<T>(i:IteratorHelper<T>):Iterator<T> {
+    return i.underlying();
+  }
+
+  inline public function underlying():Iterator<T> return this;
+}


### PR DESCRIPTION
Latest haxe fails with that inline function strategy: Instead, it fails with errors like:
```
inline_setIterator.T should be Int
```

This seems to be a Haxe problem, which will be reported. But this fixes it for now, and plus is a compile-time only feature, which is pretty nice

* [ ] @dogles 